### PR TITLE
Fix github actions using outdated JDK

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -9,10 +9,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: 17
 
       - name: Configure Maven settings
         run: cp settings.xml $HOME/.m2/settings.xml


### PR DESCRIPTION
This won't fix the build issue on it's own since there is a separate build issue linked to the UltimateClaims plugin.
This part of the fix is related only to the JDK version update for the github actions.

This will not make BetterRTP java 17+, only allowing newer classes to be used during the compilation process, such as for dependencies.