### PR TITLE
Add FactionsBridge Support (#131)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,6 +157,10 @@
             <id>devmart-other</id>
             <url>https://nexuslite.gcnt.net/repos/other/</url>
         </repository>
+        <repository>
+            <id>devmart-public</id>
+            <url>https://nexuslite.gcnt.net/repos/public/</url>
+        </repository>
     </repositories>
     <dependencies>
         <!--Spigot API-->
@@ -343,6 +347,12 @@
             <artifactId>FoliaLib</artifactId>
             <version>0.2.3-legacy-support</version>
             <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.dansplugins.factionsystem</groupId>
+            <artifactId>FactionsBridge</artifactId>
+            <version>1.3.8</version>
+            <scope>provided</scope>
         </dependency>
         <!-- CAN BE UNCOMMENTED IF YOU HAVE ACCESS TO THE PLUGIN -->
         <!-- Private Repoed -->

--- a/src/main/java/me/SuperRonanCraft/BetterRTP/references/depends/regionPlugins/REGIONPLUGINS.java
+++ b/src/main/java/me/SuperRonanCraft/BetterRTP/references/depends/regionPlugins/REGIONPLUGINS.java
@@ -19,8 +19,8 @@ public enum REGIONPLUGINS {
     ULTIMATECLAIMS("UltimateClaims", new RTP_UltimateClaims()),
     WORLDGUARD("WorldGuard", new RTP_WorldGuard()),
     MINEPLOTS("MinePlots", new RTP_MinePlots()),
+    FACTIONSBRIDGE("FactionsBridge", new RTP_FactionsBridge());
 
-    ;
     @Getter private final SoftDepends.RegionPlugin plugin = new SoftDepends.RegionPlugin();
     @Getter private final String setting_name, pluginyml_name;
     @Getter private final RegionPluginCheck validator;

--- a/src/main/java/me/SuperRonanCraft/BetterRTP/references/depends/regionPlugins/RTP_FactionsBridge.java
+++ b/src/main/java/me/SuperRonanCraft/BetterRTP/references/depends/regionPlugins/RTP_FactionsBridge.java
@@ -1,0 +1,22 @@
+package me.SuperRonanCraft.BetterRTP.references.depends.regionPlugins;
+
+import cc.javajobs.factionsbridge.FactionsBridge;
+import org.bukkit.Location;
+
+public class RTP_FactionsBridge implements RegionPluginCheck {
+
+    // NOT TESTED (3.6.9)
+    // FactionsBridge (v1.3.8)
+    // https://www.spigotmc.org/resources/factionsbridge.89716/
+    public boolean check(Location loc) {
+        boolean result = true;
+        if (REGIONPLUGINS.FACTIONSBRIDGE.isEnabled())
+            try {
+                boolean claimed = FactionsBridge.getFactionsAPI().getClaim(loc).isClaimed();
+                result = !claimed;
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        return result;
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -35,6 +35,8 @@ Settings:
     SaberFactions: false
     ## Respect HuskTowns areas (https://www.spigotmc.org/resources/husktowns.92672/) (Added in 3.4.5)
     HuskTowns: false
+    ## Respect FactionsBridge compatible claims (https://www.spigotmc.org/resources/factionsbridge.89716/) (Added in 3.6.9)
+    FactionsBridge: false
 
   ## Output to console some debugging info
   Debugger: false


### PR DESCRIPTION
Fixes #131 
Uses FactionsBridge which is compatible with many Factions plugins such that individual support doesn't need to be added for every Factions plugin.