### PR TITLE
Fix comment in config

### DIFF
--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -143,7 +143,7 @@ WorldType: # Available types are NORMAL, NETHER
   - world_nether: NETHER
   - world_the_end: NORMAL
 
-PermissionGroup: #Player requires "betterrtp.group.<world_name>" to trigger these configs
+PermissionGroup: #Player requires "betterrtp.group.<group_name>" to trigger these configs
   Enabled: false
   Groups:
     - vip: # permission: betterrtp.group.vip


### PR DESCRIPTION
Config was telling you to use world_name for the permission group section. I am pretty sure you meant group_name