### PR TITLE
fix cannot add effects to entities async

### DIFF
--- a/src/main/java/me/SuperRonanCraft/BetterRTP/BetterRTP.java
+++ b/src/main/java/me/SuperRonanCraft/BetterRTP/BetterRTP.java
@@ -28,7 +28,6 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import java.util.List;
-import java.util.logging.Level;
 
 public class BetterRTP extends JavaPlugin {
     @Getter private final Permissions perms = new Permissions();

--- a/src/main/java/me/SuperRonanCraft/BetterRTP/player/rtp/RTPTeleport.java
+++ b/src/main/java/me/SuperRonanCraft/BetterRTP/player/rtp/RTPTeleport.java
@@ -74,13 +74,15 @@ public class RTPTeleport {
     //Effects
 
     public void afterTeleport(Player p, Location loc, WorldPlayer wPlayer, int attempts, Location oldLoc, RTP_TYPE type) { //Only a successful rtp should run this OR '/rtp test'
-        effects.getSounds().playTeleport(p);
-        effects.getParticles().display(p);
-        effects.getPotions().giveEffects(p);
-        effects.getTitles().showTitle(RTPEffect_Titles.RTP_TITLE_TYPE.TELEPORT, p, loc, attempts, 0);
-        if (effects.getTitles().sendMsg(RTPEffect_Titles.RTP_TITLE_TYPE.TELEPORT))
-            sendSuccessMsg(p, p.getName(), loc, wPlayer, true, attempts);
-        getPl().getServer().getPluginManager().callEvent(new RTP_TeleportPostEvent(p, loc, oldLoc, wPlayer, type));
+        getPl().getFoliaHandler().get().runAtLocation(loc, () -> {
+            effects.getSounds().playTeleport(p);
+            effects.getParticles().display(p);
+            effects.getPotions().giveEffects(p);
+            effects.getTitles().showTitle(RTPEffect_Titles.RTP_TITLE_TYPE.TELEPORT, p, loc, attempts, 0);
+            if (effects.getTitles().sendMsg(RTPEffect_Titles.RTP_TITLE_TYPE.TELEPORT))
+                sendSuccessMsg(p, p.getName(), loc, wPlayer, true, attempts);
+            getPl().getServer().getPluginManager().callEvent(new RTP_TeleportPostEvent(p, loc, oldLoc, wPlayer, type));
+        });
     }
 
     public boolean beforeTeleportInstant(CommandSender sendi, Player p) {


### PR DESCRIPTION
fixes this error that happens

```
[04:52:07 ERROR]: Thread Region Scheduler Thread #0 failed main thread check: Cannot add effects to entities asynchronously
java.lang.Throwable: null
        at io.papermc.paper.util.TickThread.ensureTickThread(TickThread.java:78) ~[folia-1.20.1.jar:git-Folia-"6b978f2"]
        at net.minecraft.world.entity.LivingEntity.addEffect(LivingEntity.java:1148) ~[?:?]
        at net.minecraft.world.entity.LivingEntity.addEffect(LivingEntity.java:1140) ~[?:?]
        at org.bukkit.craftbukkit.v1_20_R1.entity.CraftLivingEntity.addPotionEffect(CraftLivingEntity.java:463) ~[folia-1.20.1.jar:git-Folia-"6b978f2"]
        at org.bukkit.craftbukkit.v1_20_R1.entity.CraftLivingEntity.addPotionEffect(CraftLivingEntity.java:457) ~[folia-1.20.1.jar:git-Folia-"6b978f2"]
        at org.bukkit.craftbukkit.v1_20_R1.entity.CraftLivingEntity.addPotionEffects(CraftLivingEntity.java:471) ~[folia-1.20.1.jar:git-Folia-"6b978f2"]
        at me.SuperRonanCraft.BetterRTP.player.rtp.effects.RTPEffect_Potions.giveEffects(RTPEffect_Potions.java:62) ~[BetterRTP-3.6.10.jar:?]
        at me.SuperRonanCraft.BetterRTP.player.rtp.RTPTeleport.afterTeleport(RTPTeleport.java:79) ~[BetterRTP-3.6.10.jar:?]
        at me.SuperRonanCraft.BetterRTP.player.rtp.RTPTeleport$1.run(RTPTeleport.java:58) ~[BetterRTP-3.6.10.jar:?]
        at java.util.concurrent.CompletableFuture.uniRunNow(CompletableFuture.java:819) ~[?:?]
        at java.util.concurrent.CompletableFuture.uniRunStage(CompletableFuture.java:803) ~[?:?]
        at java.util.concurrent.CompletableFuture.thenRun(CompletableFuture.java:2195) ~[?:?]
        at me.SuperRonanCraft.BetterRTP.player.rtp.RTPTeleport.sendPlayer(RTPTeleport.java:55) ~[BetterRTP-3.6.10.jar:?]
        at me.SuperRonanCraft.BetterRTP.player.rtp.RTPPlayer.lambda$attempt$3(RTPPlayer.java:97) ~[BetterRTP-3.6.10.jar:?]
        at com.tcoded.folialib.impl.FoliaImplementation.lambda$runNextTick$0(FoliaImplementation.java:38) ~[BetterRTP-3.6.10.jar:?]
        at io.papermc.paper.threadedregions.scheduler.FoliaGlobalRegionScheduler.lambda$execute$0(FoliaGlobalRegionScheduler.java:46) ~[folia-1.20.1.jar:?]
        at io.papermc.paper.threadedregions.scheduler.FoliaGlobalRegionScheduler$GlobalScheduledTask.run(FoliaGlobalRegionScheduler.java:178) ~[folia-1.20.1.jar:?]
        at io.papermc.paper.threadedregions.scheduler.FoliaGlobalRegionScheduler.tick(FoliaGlobalRegionScheduler.java:36) ~[folia-1.20.1.jar:?]
        at io.papermc.paper.threadedregions.RegionizedServer.globalTick(RegionizedServer.java:294) ~[folia-1.20.1.jar:git-Folia-"6b978f2"]
        at io.papermc.paper.threadedregions.RegionizedServer$GlobalTickTickHandle.tickRegion(RegionizedServer.java:149) ~[folia-1.20.1.jar:git-Folia-"6b978f2"]
        at io.papermc.paper.threadedregions.TickRegionScheduler$RegionScheduleHandle.runTick(TickRegionScheduler.java:385) ~[folia-1.20.1.jar:git-Folia-"6b978f2"]
        at ca.spottedleaf.concurrentutil.scheduler.SchedulerThreadPool$TickThreadRunner.run(SchedulerThreadPool.java:525) ~[folia-1.20.1.jar:git-Folia-"6b978f2"]
```