### PR TITLE
Added support for 2.0.0 beta version of UltimateClaims

### DIFF
--- a/src/main/java/me/SuperRonanCraft/BetterRTP/references/depends/regionPlugins/RTP_UltimateClaims.java
+++ b/src/main/java/me/SuperRonanCraft/BetterRTP/references/depends/regionPlugins/RTP_UltimateClaims.java
@@ -17,7 +17,12 @@ public class RTP_UltimateClaims implements RegionPluginCheck {
                 Chunk chunk = loc.getChunk();
 
                 // Get instance of UltimateClaims
-                Class<?> ultimateClaimsClass = Class.forName("com.songoda.ultimateclaims.UltimateClaims");
+                Class<?> ultimateClaimsClass;
+                try {
+                    ultimateClaimsClass = Class.forName("com.songoda.ultimateclaims.UltimateClaims");
+                } catch(ClassNotFoundException error) {
+                    ultimateClaimsClass = Class.forName("com.craftaro.ultimateclaims.UltimateClaims");
+                }
                 Method getInstanceMethod = ultimateClaimsClass.getMethod("getInstance");
                 Object ultimateClaims = getInstanceMethod.invoke(null);
 


### PR DESCRIPTION
In the new beta version of UltimateClaims from their github they changed the package name from com.songoda.ultimateclaims to com.craftaro.ultimateclaims. I added a check so that the plugin works with both the old and the new versions.