### PR TITLE
fix: Support RegionPlugin `UltimateClaims` v2 and v1

### DIFF
--- a/src/main/java/me/SuperRonanCraft/BetterRTP/references/depends/regionPlugins/RTP_UltimateClaims.java
+++ b/src/main/java/me/SuperRonanCraft/BetterRTP/references/depends/regionPlugins/RTP_UltimateClaims.java
@@ -8,9 +8,11 @@ import java.lang.reflect.Method;
 
 public class RTP_UltimateClaims implements RegionPluginCheck {
 
-    // TESTED (v2.2.0)
+    // TESTED (v3.6.12)
     // UltimateClaims (v2.2.0 + v1.10.4)
-    // https://craftaro.com/marketplace/product/65
+    // Download @ https://songoda.com/product/ultimateclaims-14
+    // V1: https://github.com/craftaro/UltimateClaims/commit/e42376975a59874b05e8516eae1545e94775add5
+    // V2: https://github.com/craftaro/UltimateClaims/commit/261d83b8712c5ec967f2aa836521c1ff9065ac91
     public boolean check(Location loc) {
         boolean result = true;
         if (REGIONPLUGINS.ULTIMATECLAIMS.isEnabled())

--- a/src/main/java/me/SuperRonanCraft/BetterRTP/references/depends/regionPlugins/RTP_UltimateClaims.java
+++ b/src/main/java/me/SuperRonanCraft/BetterRTP/references/depends/regionPlugins/RTP_UltimateClaims.java
@@ -2,38 +2,39 @@ package me.SuperRonanCraft.BetterRTP.references.depends.regionPlugins;
 
 import org.bukkit.Chunk;
 import org.bukkit.Location;
+import org.bukkit.plugin.java.JavaPlugin;
 
 import java.lang.reflect.Method;
 
 public class RTP_UltimateClaims implements RegionPluginCheck {
 
-    // NOT TESTED (3.1.0)
-    // UltimateClaims (v1.6.1) - Abandoned
-    // https://songoda.com/marketplace/product/ultimateclaims-the-ultimate-claiming-plugin.65
+    // TESTED (v2.2.0)
+    // UltimateClaims (v2.2.0 + v1.10.4)
+    // https://craftaro.com/marketplace/product/65
     public boolean check(Location loc) {
         boolean result = true;
         if (REGIONPLUGINS.ULTIMATECLAIMS.isEnabled())
             try {
-                Chunk chunk = loc.getChunk();
-
-                // Get instance of UltimateClaims
-                Class<?> ultimateClaimsClass = Class.forName("com.songoda.ultimateclaims.UltimateClaims");
-                Method getInstanceMethod = ultimateClaimsClass.getMethod("getInstance");
-                Object ultimateClaims = getInstanceMethod.invoke(null);
+                JavaPlugin ultimateClaimsInstance = JavaPlugin.getPlugin((Class<? extends JavaPlugin>) getPluginMainClass());
 
                 // Get the ClaimManager
-                Method getClaimManagerMethod = ultimateClaimsClass.getMethod("getClaimManager");
-                Object claimManager = getClaimManagerMethod.invoke(ultimateClaims);
+                Method getClaimManagerMethod = ultimateClaimsInstance.getClass().getMethod("getClaimManager");
+                Object claimManager = getClaimManagerMethod.invoke(ultimateClaimsInstance);
 
                 // Get the claim based on the chunk
-                Method getClaimMethod = claimManager.getClass().getMethod("getClaim", Chunk.class);
-                Object claimObj = getClaimMethod.invoke(claimManager, chunk);
-
-                // Check if a claim exists
-                return claimObj == null;
+                Method hasClaimMethod = claimManager.getClass().getMethod("hasClaim", Chunk.class);
+                return Boolean.FALSE.equals(hasClaimMethod.invoke(claimManager, loc.getChunk()));
             } catch (Exception e) {
                 e.printStackTrace();
             }
         return result;
+    }
+
+    private Class<?> getPluginMainClass() throws ClassNotFoundException {
+        try {
+            return Class.forName("com.craftaro.ultimateclaims.UltimateClaims"); // v2
+        } catch (ClassNotFoundException ignore) {
+            return Class.forName("com.songoda.ultimateclaims.UltimateClaims");  // v1
+        }
     }
 }


### PR DESCRIPTION
* This patch has been tested by a user affected by this bug
* The URL to the plugin changed, you might want to update the link on your Spigot-Plugin-Page (https://craftaro.com/marketplace/product/65)
* I tried keeping the code style similar to the existing files

---

With UltimateClaims v2 the package changed because Songoda renamed to Craftaro at one point.

This fixes a `ClassNotFoundException` when using v2 of the plugin. The commit also refactors the code a bit as the `UltimateClaims#getInstance()` method is marked as deprecated and will be removed in the future.